### PR TITLE
fix binding style attribute warning in Ember 1.11

### DIFF
--- a/addon/components/spin-spinner.js
+++ b/addon/components/spin-spinner.js
@@ -34,7 +34,7 @@ export default Ember.Component.extend({
   top: '50%',
 
   style: function () {
-    return 'position: absolute; width: 0; height: 0; left: '+ this.get('left') +'; top: '+ this.get('top') +';';
+    return ('position: absolute; width: 0; height: 0; left: '+ this.get('left') +'; top: '+ this.get('top') +';').htmlSafe();
   }.property('top', 'left'),
 
   startSpinner: function () {


### PR DESCRIPTION
Ember 1.11 introduced a warning about binding the style attribute since it could lead  an cross-site scripting (XSS) vulnerability. 
