### PR TITLE
Workaround when using ember-spin-spinner in nested addon

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,7 +20,11 @@ module.exports = {
      * to do the below imports itself in its included hook.
      */
     if (typeof(app.import) === 'function') {
-      var spinPath = path.join(app.bowerDirectory, 'spin.js');
+      var bowerDirectory = app.bowerDirectory;
+      if (!bowerDirectory && app.app) {
+        bowerDirectory = app.app.bowerDirectory;
+      }
+      var spinPath = path.join(bowerDirectory, 'spin.js');
 
       app.import(path.join(spinPath, 'spin.js'));
       app.import(path.join(spinPath, 'jquery.spin.js'));

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-spin-spinner",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "Ember component wrapper for spin.js.",
   "keywords": [
     "ember-addon",


### PR DESCRIPTION
I use ember-spinner-button in a private addon. I'm currently upgrading my addon and applications to Ember CLI 2.18 from 2.3. After upgrading my application fails to start because app.bowerDirectory in index.js is null in the nested addon case. However, app.app.bowerDirectory works fine. I've seen this workaround implemented in other addons, would it be OK to use this here?